### PR TITLE
Add documentation about 'user_name', 'password', 'on_error' attributes.

### DIFF
--- a/lib/AnyEvent/MQTT.pm
+++ b/lib/AnyEvent/MQTT.pm
@@ -77,6 +77,14 @@ The timeout for responses from the server.
 
 The keep alive timer.
 
+=item C<user_name>
+
+The user name for the MQTT broker.
+
+=item C<password>
+
+The password for the MQTT broker.
+
 =item C<will_topic>
 
 Set topic for will message.  Default is undef which means no will
@@ -107,6 +115,18 @@ is C<Net::MQTT::Message[NNNNN]> where NNNNN is the process id.
 =item C<message_log_callback>
 
 Defines a callback to call on every message.
+
+=item C<on_error>
+
+Defines a callback to call when some error occurs.
+
+Two params are passed to the callback.
+
+    $on_error->($fatal, $message)
+
+where C<$fatal> is a boolean flag and C<$message> is the error message.
+If the error is fatal, C<$fatal> is true.
+
 
 =back
 


### PR DESCRIPTION
Especially user_name and password are important to connect to MQTT brokers.
