### PR TITLE
Add 'handle_args' to the constructor.

### DIFF
--- a/lib/AnyEvent/MQTT.pm
+++ b/lib/AnyEvent/MQTT.pm
@@ -127,6 +127,11 @@ Two parameters are passed to the callback.
 where C<$fatal> is a boolean flag and C<$message> is the error message.
 If the error is fatal, C<$fatal> is true.
 
+=item C<handle_args>
+
+  a reference to a list to pass as arguments to the
+  L<AnyEvent::Handle> constructor (defaults to
+  an empty list reference).
 
 =back
 
@@ -152,6 +157,7 @@ sub new {
            will_message => '',
            client_id => undef,
            clean_session => 1,
+           handle_args => [],
            write_queue => [],
            inflight => {},
            _sub_topics => Net::MQTT::TopicStore->new(),
@@ -675,7 +681,9 @@ sub connect {
                                                 1;
                                               });
                             });
-                          }));
+                          }),
+                          @{$self->{handle_args}},
+                         );
   return $cv
 }
 


### PR DESCRIPTION
Hi,

Here's a patch to add handle_args to new().  I used this to enable TLS for MQTT.

Thanks
Matt