### PR TITLE
Support disabling clean session

### DIFF
--- a/lib/AnyEvent/MQTT.pm
+++ b/lib/AnyEvent/MQTT.pm
@@ -287,6 +287,18 @@ sub _confirm_subscription {
   foreach my $cv (@{$rec->{cv}}) {
     $cv->send($qos);
   }
+
+  # publish any matching queued QoS messages
+  if (!$self->{clean_session} && $qos && $self->{_qos_msg_cache}) {
+    my $cache = $self->{_qos_msg_cache};
+    my $ts = Net::MQTT::TopicStore->new($topic);
+    for my $i (grep { $ts->values($cache->[$_]->topic) } reverse(0..$#$cache)) {
+      my $msg = delete $cache->[$i];
+      print STDERR "Processing cached message for topic '", $msg->topic, "' with subscription to topic '$topic'\n" if DEBUG;
+      $self->_process_publish($self->{handle}, $msg);
+    }
+    delete $self->{_qos_msg_cache} unless @$cache;
+  }
   delete $rec->{cv};
 }
 
@@ -553,6 +565,14 @@ sub _publish_locally {
 sub _process_publish {
   my ($self, $handle, $msg, $error) = @_;
   my $qos = $msg->qos;
+
+  # assuming this was intended for a subscription not yet restored
+  if ($qos && !$self->{clean_session} && !@{$self->{_sub_topics}->values($msg->topic)}) {
+    print STDERR "Caching message for '", $msg->topic, "'\n" if DEBUG;
+    push(@{$self->{_qos_msg_cache}}, $msg);
+    return;
+  }
+
   if ($qos == MQTT_QOS_EXACTLY_ONCE) {
     my $mid = $msg->message_id;
     $self->{messages}->{$mid} = $msg;


### PR DESCRIPTION
This fixes issue #2

Messages with QoS > 0 might be delievered by the broker immediately after
connect when clean_session is disabled.  This happens before we have set
up our subscription callback(s). Store these messages for later processing
instead of rejecting them. Stored messages will be processed by the first
matching subscription.

Signed-off-by: Bjørn Mork <bmork@telenor.net>