### PR TITLE
Avoid zero message_id on wrapping.

### DIFF
--- a/lib/AnyEvent/MQTT.pm
+++ b/lib/AnyEvent/MQTT.pm
@@ -138,7 +138,7 @@ sub next_message_id {
   my $self = shift;
   my $res = $self->{message_id};
   $self->{message_id}++;
-  $self->{message_id} %= 65536;
+  $self->{message_id} = 1 if $self->{message_id} >= 65536;
   $res;
 }
 

--- a/t/01-publish.t
+++ b/t/01-publish.t
@@ -133,7 +133,8 @@ is_deeply(\@messages,
 
 my $ok = 1;
 foreach (0..70000) {
-  next if ($mqtt->next_message_id < 65536);
+  my $mid = $mqtt->next_message_id;
+  next if (0 < $mid && $mid < 65536);
   $ok = 0;
 }
 ok($ok, '... message id should never exceed 16bit size');


### PR DESCRIPTION
Noticed on newer versions of mosquitto clients were crashing at regular intervals.  Tracked it down to a 'protocol error' message in mosquitto which was caused by a zero message_id that is sent when the message_id wraps.

This is a patch to avoid zero message id's.

Below is a simple script to test.  I tested against mosquitto 1.6.10 and it crashed when the message id wraps.
```
#!/usr/bin/perl

use AnyEvent::MQTT;

my $mqtt = AnyEvent::MQTT->new (
  host      => $ARGV[0] // '127.0.0.1',
  on_error  => sub {
     my ($fatal, $message) = @_;
     warn "MQTT (" . ($fatal ? "fatal" : "non-fatal") . ") error: $message";
     exit 1 if ($fatal);
  }
);

while ( 1 ) {
  my $cv = $mqtt->subscribe(topic    => 'test_topic',
                            callback => sub { });
  $cv->recv;

  $cv = $mqtt->unsubscribe(topic    => 'test_topic');
  $cv->recv;
}
```
